### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,47 @@ Dependencies on other Microservices:
 
 ## Getting Started
 
-### OS X
-
 **First, make sure that you have the [API gateway running
-locally](https://github.com/control-tower/control-tower).**
+locally](https://github.com/Vizzuality/api-gateway/tree/production#getting-started).**
 
-We're using Docker which, luckily for you, means that getting the
-application running locally should be fairly painless. First, make sure
-that you have [Docker Compose](https://docs.docker.com/compose/install/)
-installed on your machine.
+Start by cloning the repository from github to your execution environment
 
 ```
-git clone https://github.com/Vizzuality/node-skeleton
-cd node-skeleton
-./nodeSkeleton.sh develop
-```text
+git clone https://github.com/resource-watch/task-executor.git && cd task-executor
+```
 
-You can now access the microservice through the CT gateway.
+After that, follow one of the instructions below:
+
+### Using native execution
+
+1 - Set up your environment variables. See `dev.env.sample` for a list of variables you should set, which are described in detail in [this section](#environment-variables) of the documentation. Native execution will NOT load the `dev.env` file content, so you need to use another way to define those values
+
+2 - Install node dependencies using yarn:
+```
+yarn
+```
+
+3 - Start the application server:
+```
+yarn start
+```
+
+The endpoints provided by this microservice should now be available through Control Tower's URL.
+
+### Using Docker
+
+1 - Create and complete your `dev.env` file with your configuration. You can find an example `dev.env.sample` file in the project root.
+
+2 - Execute the following command to run Control tower:
 
 ```
+./task.sh develop
+```
+
+The endpoints provided by this microservice should now be available through Control Tower's URL.
+
+
+You can now access the microservice through the API gateway.
 
 ### Configuration
 

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -3,8 +3,11 @@ services:
   develop:
     build: .
     ports:
-      - "35739:35729"
+      - "5005:5005"
     environment:
+      PORT: 5005
+      NODE_ENV: dev
+      NODE_PATH: app/src
       CT_REGISTER_MODE: auto
       CT_URL: http://mymachine:9000
       LOCAL_URL: http://mymachine:5005


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Update README to be consistent with other repos
- Update port and set node env and path